### PR TITLE
Add isolated SQLite tests for links

### DIFF
--- a/src/links.rs
+++ b/src/links.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use sqlx::Row;
 use std::collections::HashMap;
 
-use crate::{security, AppState};
+use crate::{AppState, security};
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Link {
@@ -281,4 +281,193 @@ pub async fn get_categories() -> Result<Json<Vec<String>>, StatusCode> {
         "Content Creators".to_string(),
     ];
     Ok(Json(categories))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::extract::State;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    use crate::config::{
+        AdminConfig, AppConfig, CorsConfig, DatabaseConfig, LoggingConfig, RatingsConfig,
+        SecurityConfig, ServerConfig,
+    };
+    use crate::{classes, instances, zones};
+
+    async fn setup_state() -> AppState {
+        let pool = sqlx::SqlitePool::connect(":memory:")
+            .await
+            .expect("failed to create pool");
+
+        sqlx::query(
+            r#"CREATE TABLE links (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL,
+                url TEXT NOT NULL,
+                category TEXT NOT NULL,
+                description TEXT,
+                created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+                updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+            )"#,
+        )
+        .execute(&pool)
+        .await
+        .expect("failed to create table");
+
+        let pool = Arc::new(pool);
+
+        let config = Arc::new(AppConfig {
+            server: ServerConfig {
+                port: 0,
+                host: "localhost".into(),
+            },
+            database: DatabaseConfig {
+                path: String::new(),
+                backup_dir: String::new(),
+                migrate_on_startup: false,
+            },
+            security: SecurityConfig {
+                rating_ip_hash_key: "key".into(),
+                min_ip_hash_key_length: 0,
+            },
+            ratings: RatingsConfig {
+                min_rating: 0,
+                max_rating: 5,
+                transaction_log_path: String::new(),
+            },
+            admin: AdminConfig {
+                enabled: false,
+                page_size: 0,
+                min_page_size: 0,
+                max_page_size: 0,
+                default_sort_column: String::new(),
+                default_sort_order: String::new(),
+            },
+            cors: CorsConfig {
+                development_origins: vec![],
+                production_origins: vec![],
+            },
+            logging: LoggingConfig {
+                level: String::new(),
+                format: String::new(),
+                file_path: String::new(),
+                max_file_size: String::new(),
+                max_files: 0,
+            },
+        });
+
+        AppState {
+            config,
+            zone_state: zones::ZoneState { pool: pool.clone() },
+            instance_state: instances::InstanceState { pool: pool.clone() },
+            class_race_state: classes::ClassRaceState {
+                class_race_map: Arc::new(HashMap::new()),
+            },
+        }
+    }
+
+    #[tokio::test]
+    async fn create_link_persists_and_sanitizes() {
+        let state = setup_state().await;
+        let form = LinkForm {
+            name: "<script>bad</script>Good".into(),
+            url: "https://example.com".into(),
+            category: "General".into(),
+            description: Some("<b>Bold</b><script>x</script>".into()),
+        };
+
+        let Json(link) = create_link(State(state.clone()), Json(form))
+            .await
+            .expect("create link failed");
+
+        let row = sqlx::query("SELECT name, description FROM links WHERE id = ?")
+            .bind(link.id)
+            .fetch_one(state.zone_state.pool.as_ref())
+            .await
+            .expect("query failed");
+
+        let name: String = row.get("name");
+        let description: Option<String> = row.get("description");
+
+        assert_eq!(name, "Good");
+        assert_eq!(description.as_deref(), Some("<b>Bold</b>x"));
+    }
+
+    #[tokio::test]
+    async fn create_link_rejects_malicious_url() {
+        let state = setup_state().await;
+        let form = LinkForm {
+            name: "Test".into(),
+            url: "javascript:alert(1)".into(),
+            category: "General".into(),
+            description: None,
+        };
+
+        let result = create_link(State(state), Json(form)).await;
+        assert_eq!(result.unwrap_err(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn update_link_persists_and_sanitizes() {
+        let state = setup_state().await;
+        let form = LinkForm {
+            name: "Initial".into(),
+            url: "https://example.com".into(),
+            category: "General".into(),
+            description: None,
+        };
+        let Json(link) = create_link(State(state.clone()), Json(form))
+            .await
+            .expect("create link failed");
+
+        let update_form = LinkForm {
+            name: "<b>Updated</b><script>bad</script>".into(),
+            url: "https://example.org".into(),
+            category: "General".into(),
+            description: Some("<i>Desc</i><script>x</script>".into()),
+        };
+        let Json(updated) = update_link(State(state.clone()), Path(link.id), Json(update_form))
+            .await
+            .expect("update link failed");
+
+        let row = sqlx::query("SELECT name, url, description FROM links WHERE id = ?")
+            .bind(updated.id)
+            .fetch_one(state.zone_state.pool.as_ref())
+            .await
+            .expect("query failed");
+
+        let name: String = row.get("name");
+        let url: String = row.get("url");
+        let description: Option<String> = row.get("description");
+
+        assert_eq!(name, "Updated");
+        assert_eq!(url, "https://example.org");
+        assert_eq!(description.as_deref(), Some("<i>Desc</i>x"));
+    }
+
+    #[tokio::test]
+    async fn update_link_rejects_malicious_url() {
+        let state = setup_state().await;
+        let form = LinkForm {
+            name: "Initial".into(),
+            url: "https://example.com".into(),
+            category: "General".into(),
+            description: None,
+        };
+        let Json(link) = create_link(State(state.clone()), Json(form))
+            .await
+            .expect("create link failed");
+
+        let bad_form = LinkForm {
+            name: "Bad".into(),
+            url: "javascript:alert(1)".into(),
+            category: "General".into(),
+            description: None,
+        };
+
+        let result = update_link(State(state), Path(link.id), Json(bad_form)).await;
+        assert_eq!(result.unwrap_err(), StatusCode::BAD_REQUEST);
+    }
 }


### PR DESCRIPTION
## Summary
- add in-memory SQLite setup for link tests
- cover create_link and update_link with valid and malicious inputs

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b27e21835483209271571ccb53bb8b