### PR TITLE
Add rating hash tests and validate submit_zone_rating

### DIFF
--- a/src/ratings.rs
+++ b/src/ratings.rs
@@ -9,9 +9,9 @@ use serde::{Deserialize, Serialize};
 use sqlx::{Row, SqlitePool};
 use std::fs::OpenOptions;
 use std::io::Write;
+use std::net::SocketAddr;
 use std::sync::Arc;
 use tracing::{error, warn};
-use std::net::SocketAddr;
 
 use crate::{AppError, AppResult, AppState};
 
@@ -57,6 +57,11 @@ fn hash_ip(ip: &str, config: &crate::AppConfig) -> String {
     key.copy_from_slice(hash.as_bytes());
     let h = blake3::keyed_hash(&key, ip.as_bytes());
     h.to_hex().to_string()
+}
+
+#[cfg(test)]
+pub(crate) fn test_hash_ip(ip: &str, config: &crate::AppConfig) -> String {
+    hash_ip(ip, config)
 }
 
 // Get rating statistics for a zone
@@ -110,19 +115,20 @@ pub async fn get_zone_rating(
 
     let user_ip = addr.ip().to_string();
     let hashed_ip = hash_ip(&user_ip, &state.config);
-    let user_rating = sqlx::query("SELECT rating FROM zone_ratings WHERE zone_id = ? AND user_ip = ?")
-        .bind(zone_id)
-        .bind(&hashed_ip)
-        .fetch_optional(pool)
-        .await
-        .map_err(|e| {
-            error!(
-                "Database error getting user rating for zone {}: {}",
-                zone_id, e
-            );
-            AppError::Database(e)
-        })?
-        .map(|row| row.get::<i32, _>("rating") as u8);
+    let user_rating =
+        sqlx::query("SELECT rating FROM zone_ratings WHERE zone_id = ? AND user_ip = ?")
+            .bind(zone_id)
+            .bind(&hashed_ip)
+            .fetch_optional(pool)
+            .await
+            .map_err(|e| {
+                error!(
+                    "Database error getting user rating for zone {}: {}",
+                    zone_id, e
+                );
+                AppError::Database(e)
+            })?
+            .map(|row| row.get::<i32, _>("rating") as u8);
 
     Ok(Json(ZoneRatingStats {
         zone_id,
@@ -317,4 +323,170 @@ fn write_to_transaction_log(sql_statement: &str) -> std::io::Result<()> {
     file.write_all(sql_statement.as_bytes())?;
     file.flush()?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::classes::ClassRaceState;
+    use crate::config::{
+        AdminConfig, AppConfig, CorsConfig, DatabaseConfig, LoggingConfig, RatingsConfig,
+        SecurityConfig, ServerConfig,
+    };
+    use crate::instances::InstanceState;
+    use crate::zones::ZoneState;
+    use crate::{AppError, AppState};
+    use axum::Json;
+    use axum::extract::{ConnectInfo, Path, State};
+    use sqlx::sqlite::SqlitePoolOptions;
+    use sqlx::{Row, SqlitePool};
+    use std::collections::HashMap;
+    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+    use std::sync::Arc;
+
+    fn test_config_with_key(key: &str) -> AppConfig {
+        AppConfig {
+            server: ServerConfig {
+                port: 0,
+                host: "localhost".to_string(),
+            },
+            database: DatabaseConfig {
+                path: "".to_string(),
+                backup_dir: "".to_string(),
+                migrate_on_startup: false,
+            },
+            security: SecurityConfig {
+                rating_ip_hash_key: key.to_string(),
+                min_ip_hash_key_length: 0,
+            },
+            ratings: RatingsConfig {
+                min_rating: 1,
+                max_rating: 5,
+                transaction_log_path: "".to_string(),
+            },
+            admin: AdminConfig {
+                enabled: false,
+                page_size: 10,
+                min_page_size: 1,
+                max_page_size: 100,
+                default_sort_column: "id".to_string(),
+                default_sort_order: "asc".to_string(),
+            },
+            cors: CorsConfig {
+                development_origins: vec![],
+                production_origins: vec![],
+            },
+            logging: LoggingConfig {
+                level: "info".to_string(),
+                format: "text".to_string(),
+                file_path: "".to_string(),
+                max_file_size: "1MB".to_string(),
+                max_files: 1,
+            },
+        }
+    }
+
+    async fn setup_state() -> (AppState, Arc<SqlitePool>) {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .unwrap();
+
+        sqlx::query("CREATE TABLE zones (id INTEGER PRIMARY KEY, name TEXT)")
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query(
+            r#"
+            CREATE TABLE zone_ratings (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                zone_id INTEGER NOT NULL,
+                user_ip TEXT NOT NULL,
+                rating INTEGER NOT NULL,
+                created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+                updated_at TEXT DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE(zone_id, user_ip)
+            )
+            "#,
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query("INSERT INTO zones (id, name) VALUES (1, 'Test Zone')")
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let pool_arc = Arc::new(pool);
+        let state = AppState {
+            config: Arc::new(test_config_with_key("testkey")),
+            zone_state: ZoneState {
+                pool: pool_arc.clone(),
+            },
+            instance_state: InstanceState {
+                pool: pool_arc.clone(),
+            },
+            class_race_state: ClassRaceState {
+                class_race_map: Arc::new(HashMap::new()),
+            },
+        };
+        (state, pool_arc)
+    }
+
+    #[test]
+    fn hash_ip_is_stable_and_key_dependent() {
+        let ip = "127.0.0.1";
+        let config1 = test_config_with_key("samekey");
+        let h1 = super::test_hash_ip(ip, &config1);
+        let h2 = super::test_hash_ip(ip, &config1);
+        assert_eq!(h1, h2);
+
+        let config2 = test_config_with_key("differentkey");
+        let h3 = super::test_hash_ip(ip, &config2);
+        assert_ne!(h1, h3);
+    }
+
+    #[tokio::test]
+    async fn submit_zone_rating_rejects_out_of_range() {
+        let (state, _) = setup_state().await;
+        let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0);
+        let result = submit_zone_rating(
+            Path(1),
+            ConnectInfo(addr),
+            State(state),
+            Json(SubmitRatingRequest { rating: 0 }),
+        )
+        .await;
+        assert!(matches!(result, Err(AppError::InvalidRating(0, 1, 5))));
+    }
+
+    #[tokio::test]
+    async fn submit_zone_rating_accepts_valid_rating() {
+        let (state, pool) = setup_state().await;
+        let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0);
+        let rating = 5;
+        let result = submit_zone_rating(
+            Path(1),
+            ConnectInfo(addr),
+            State(state),
+            Json(SubmitRatingRequest { rating }),
+        )
+        .await;
+        assert!(result.is_ok());
+
+        let row = sqlx::query("SELECT COUNT(*) as count FROM zone_ratings")
+            .fetch_one(&*pool)
+            .await
+            .unwrap();
+        let count: i64 = row.get("count");
+        assert_eq!(count, 1);
+
+        let row = sqlx::query("SELECT rating FROM zone_ratings WHERE zone_id = 1")
+            .fetch_one(&*pool)
+            .await
+            .unwrap();
+        let stored: i64 = row.get("rating");
+        assert_eq!(stored as u8, rating);
+    }
 }


### PR DESCRIPTION
## Summary
- expose IP hashing helper for tests
- add unit test verifying hashing key stability
- add async tests for submit_zone_rating including invalid and valid cases

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b284b56f788320b42a695c4516807f