### PR TITLE
Load rating IP hash key from environment

### DIFF
--- a/config/default.toml
+++ b/config/default.toml
@@ -10,7 +10,6 @@ backup_dir = "./backups/database"
 migrate_on_startup = true
 
 [security]
-rating_ip_hash_key = "change-this-to-a-secure-random-32plus-character-string-for-production"
 min_ip_hash_key_length = 32
 
 [ratings]

--- a/config/development.toml
+++ b/config/development.toml
@@ -10,7 +10,6 @@ backup_dir = "./backups/database"
 migrate_on_startup = true
 
 [security]
-rating_ip_hash_key = "development-key-change-for-production-use-32plus-chars"
 min_ip_hash_key_length = 32
 
 [ratings]

--- a/config/production.toml
+++ b/config/production.toml
@@ -10,7 +10,6 @@ backup_dir = "./backups/database"
 migrate_on_startup = true
 
 [security]
-rating_ip_hash_key = "change-this-to-a-secure-random-32plus-character-string-for-production"
 min_ip_hash_key_length = 32
 
 [ratings]

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -11,6 +11,6 @@ services:
     environment:
       RUST_LOG: debug
       EQ_RNG_ENV: development
-      EQ_RNG_SECURITY_RATING_IP_HASH_KEY: "development-key-change-for-production-use-32plus-chars"
+      RATING_IP_HASH_KEY: "development-key-change-for-production-use-32plus-chars"
     volumes:
       - ./data:/opt/eq_rng/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     environment:
       RUST_LOG: info
       EQ_RNG_ENV: production
-      EQ_RNG_SECURITY_RATING_IP_HASH_KEY: "change-this-to-a-secure-random-32plus-character-string-for-production"
+      RATING_IP_HASH_KEY: "change-this-to-a-secure-random-32plus-character-string-for-production"
       ALLOWED_ORIGINS: "https://eqrng.com"
     volumes:
       - ./data:/opt/eq_rng/data

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -31,7 +31,6 @@ migrate_on_startup = true
 ### Security Configuration
 ```toml
 [security]
-rating_ip_hash_key = "your-secure-key-here"
 min_ip_hash_key_length = 32
 ```
 
@@ -76,7 +75,7 @@ max_files = 5
 
 ## Environment Variables
 
-You can override any configuration value using environment variables with the `EQ_RNG_` prefix:
+You can override most configuration values using environment variables with the `EQ_RNG_` prefix. The `rating_ip_hash_key` is loaded exclusively from the `RATING_IP_HASH_KEY` environment variable:
 
 ```bash
 # Override server port
@@ -85,8 +84,8 @@ export EQ_RNG_SERVER_PORT=8080
 # Override database path
 export EQ_RNG_DATABASE_PATH="/var/lib/eq_rng/zones.db"
 
-# Override security key
-export EQ_RNG_SECURITY_RATING_IP_HASH_KEY="your-production-key-here"
+# Set the required security key
+export RATING_IP_HASH_KEY="your-production-key-here"
 
 # Override logging level
 export EQ_RNG_LOGGING_LEVEL="debug"
@@ -145,7 +144,7 @@ export EQ_RNG_ADMIN_ENABLED=true
 export EQ_RNG_ENV=production
 export EQ_RNG_LOGGING_LEVEL=info
 export EQ_RNG_ADMIN_ENABLED=false
-export EQ_RNG_SECURITY_RATING_IP_HASH_KEY="your-secure-production-key"
+export RATING_IP_HASH_KEY="your-secure-production-key"
 export EQ_RNG_SERVER_HOST="0.0.0.0"
 export EQ_RNG_SERVER_PORT=3000
 ```
@@ -159,7 +158,7 @@ When running in Docker, you can pass configuration via environment variables:
 environment:
   EQ_RNG_ENV: production
   EQ_RNG_LOGGING_LEVEL: info
-  EQ_RNG_SECURITY_RATING_IP_HASH_KEY: "your-production-key"
+  RATING_IP_HASH_KEY: "your-production-key"
 ```
 
 ## Migration from Old System


### PR DESCRIPTION
## Summary
- remove rating_ip_hash_key from config files
- load rating_ip_hash_key from `RATING_IP_HASH_KEY` env var and validate length
- update docs and Docker configs for new key handling

## Testing
- `RATING_IP_HASH_KEY=abcdefghijklmnopqrstuvwxyz012345 cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68ba28c7c0e48320adbc224550915036