### PR TITLE
Load rating hash key from environment variable

### DIFF
--- a/config/default.toml
+++ b/config/default.toml
@@ -10,6 +10,7 @@ backup_dir = "./backups/database"
 migrate_on_startup = true
 
 [security]
+# rating_ip_hash_key is loaded from the RATING_IP_HASH_KEY environment variable
 min_ip_hash_key_length = 32
 
 [ratings]

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,7 +18,7 @@ pub struct DatabaseConfig {
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct SecurityConfig {
-    #[serde(default)]
+    #[serde(skip)]
     pub rating_ip_hash_key: String,
     pub min_ip_hash_key_length: usize,
 }


### PR DESCRIPTION
## Summary
- clarify that `rating_ip_hash_key` comes from the `RATING_IP_HASH_KEY` environment variable
- ensure the key isn't deserialized from config files

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68ba2bb90c748320916d92eead4b3dd0